### PR TITLE
Add support for uploading to a media-endpoint that returns a Location header

### DIFF
--- a/src/functions/media.js
+++ b/src/functions/media.js
@@ -33,12 +33,13 @@ exports.handler = async e => {
 	})
 
 	console.log(`⇒ [${res.status}]`, res.headers)
+	const location = res.headers.get('location')
 
 	return {
 		statusCode: res.status,
 		headers: {
 			...Response.DEFAULT_HEADERS,
-			...res.headers
+			...(location && { 'Location': location })
 		},
 		body: await res.text()
 	}

--- a/src/js/Editors/ImageEditor.js
+++ b/src/js/Editors/ImageEditor.js
@@ -38,8 +38,8 @@ const ImageEditor = () => {
 			body: formData
 		})
 		if (res && res.status === 201) {
-			if (res.response && res.response.url) {
-				uploaded = res.response.url
+			if ((res.response && res.response.url) || res.headers.location) {
+				uploaded = res.response.url || res.headers.location
 				let media = Store.getCache('media') || []
 				media.unshift({ url: uploaded })
 				Store.addToCache({ media })


### PR DESCRIPTION
Fixes #4.

I've tested this locally with my media endpoint in two configurations:

- Returning 201 with empty body and `Location` header on success
- Returning 201 with `{'url': <url>}` as body and no `Location` header on success

If both the `url` in the body and the `Location` header are set I've kept the existing behaviour of using the response body.