### PR TITLE
feat: support checked syndication targets

### DIFF
--- a/src/js/Editors/index.js
+++ b/src/js/Editors/index.js
@@ -88,18 +88,18 @@ const Editor = ({ attrs }) => {
 		state.content = `![](${params.image.replace(' ', '%20')})`
 	}
 
-	const updateSyndicateTo = (e, syndicateTarget) => {
-		if (e && e.target && e.target.checked) {
-			state['mp-syndicate-to'] = [...(state['mp-syndicate-to'] || []), syndicateTarget.uid]
-		} else {
-			state['mp-syndicate-to'] = (state['mp-syndicate-to'] || []).filter(e => e != syndicateTarget.uid)
-		}
-	}
-
 	const post = async (e) => {
 		e.preventDefault()
 
 		let properties = {}
+
+		const mpSyndicateTo = e.target.querySelectorAll('.mp-syndicate-to')
+		if (mpSyndicateTo) {
+			state['mp-syndicate-to'] = [...mpSyndicateTo]
+				.filter(element => element.checked)
+				.map(element => element.value)
+		}
+
 		for (const [key, value] of Object.entries(state)) {
 			if (key != 'category' && value && value.length) {
 				properties[key] = Array.isArray(value) ? value : [ value ]
@@ -242,7 +242,11 @@ const Editor = ({ attrs }) => {
 								m('li', [
 									m('label', [
 										s.name,
-										m('input', { type: 'checkbox', onchange: e => updateSyndicateTo(e, s) })
+										m('input.mp-syndicate-to', {
+											type: 'checkbox',
+											checked: s.checked,
+											value: s.uid
+										})
 									])
 								]))
 						])

--- a/src/js/Editors/index.js
+++ b/src/js/Editors/index.js
@@ -245,7 +245,8 @@ const Editor = ({ attrs }) => {
 										m('input.mp-syndicate-to', {
 											type: 'checkbox',
 											checked: s.checked,
-											value: s.uid
+											value: s.uid,
+											onchange: e => s.checked = e.target.checked
 										})
 									])
 								]))


### PR DESCRIPTION
This PR attempts to add support for [the `checked` property](https://github.com/indieweb/micropub-extensions/issues/23) that can be returned in a query for an endpoint’s syndication targets.

I thought it might be as easy as adding the following to the individual checkboxes:

```diff
  m('label', [
    s.name,
    m('input', {
      type: 'checkbox',
+     checked: s.checked,
      onchange: e => updateSyndicateTo(e, s)
    })
  ])
```

While that worked, it prevented the checkboxes from being toggled. Also, `updateSyndicateTo` updates the `mp-syndicate-to` property when a checkbox is interacted with; with pre-checked checkboxes, a user might not interact with these form elements at all.

So instead I’m now calculating which syndication checkboxes have been checked on form submit.

However, perhaps given the way Mithril.js works – maybe updating and reseting the DOM on every event, I’m not sure – interacting with any other form element will reset the checkboxes back to their original state.

Hopefully there is enough here to begin reviewing this feature, and just a small change is needed to make this PR work as intended.