### PR TITLE
feat: support preferred vocabulary name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparkles",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sparkles",
-      "version": "0.5.1",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",
@@ -15,7 +15,7 @@
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
-        "eslint": "^8.53.0",
+        "eslint": "^8.54.0",
         "sass": "^1.69.5",
         "vite": "^4.5.0"
       },
@@ -433,9 +433,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
-      "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.54.0.tgz",
+      "integrity": "sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -961,15 +961,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
-      "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.54.0.tgz",
+      "integrity": "sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.3",
-        "@eslint/js": "8.53.0",
+        "@eslint/js": "8.54.0",
         "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkles",
-  "version": "0.5.1",
+  "version": "0.6.1",
   "description": "micropub client",
   "main": "./src/js/app.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "url": "https://github.com/benjifs/sparkles/issues"
   },
   "devDependencies": {
-    "eslint": "^8.53.0",
+    "eslint": "^8.54.0",
     "sass": "^1.69.5",
     "vite": "^4.5.0"
   },

--- a/src/js/Editors/BookEditor.js
+++ b/src/js/Editors/BookEditor.js
@@ -5,6 +5,7 @@ import { Box } from '../Components/Box'
 import { Modal } from '../Components/Modal'
 import Rating from '../Components/Rating'
 import Proxy from '../Controllers/Proxy'
+import Store from '../Models/Store'
 import { dateInRFC3339, ratingToStars } from '../utils'
 
 const OPENLIBRARY_URL = 'https://openlibrary.org'
@@ -20,6 +21,7 @@ const getStatusForProgress = key => PROGRESS_OPTIONS.find(p => p.key == key).lab
 const getOpenLibraryImage = id => id ? `https://covers.openlibrary.org/b/id/${id}-M.jpg` : ''
 
 const BookEditor = () => {
+	const postTypes = Store.getSession('post-types') || []
 	let state = {
 		progress: DEFAULT_PROGRESS
 	}
@@ -128,11 +130,13 @@ const BookEditor = () => {
 		timeout = setTimeout(submitSearch, 2000)
 	}
 
+	const postType = postTypes.find(item => item.type == 'read')
+
 	return {
 		view: () =>
 			m(Box, {
 				icon: '.fas.fa-book',
-				title: 'Book'
+				title: postType?.name || 'Book'
 			}, [
 				m('form', {
 					onsubmit: submitSearch

--- a/src/js/Editors/MovieEditor.js
+++ b/src/js/Editors/MovieEditor.js
@@ -5,6 +5,7 @@ import { Box } from '../Components/Box'
 import { Modal } from '../Components/Modal'
 import Rating from '../Components/Rating'
 import Proxy from '../Controllers/Proxy'
+import Store from '../Models/Store'
 import { dateInRFC3339, ratingToStars } from '../utils'
 
 const OMDB_API_KEY = import.meta.env.VITE_OMDB_API_KEY
@@ -33,6 +34,7 @@ const MovieEditor = () => {
 				])
 		}
 	}
+	const postTypes = Store.getSession('post-types') || []
 
 	let state = {}
 
@@ -134,11 +136,13 @@ const MovieEditor = () => {
 		timeout = setTimeout(submitSearch, 2000)
 	}
 
+	const postType = postTypes.find(item => item.type == 'watch')
+
 	return {
 		view: () =>
 			m(Box, {
 				icon: '.fas.fa-film',
-				title: 'Movie'
+				title: postType?.name || 'Movie'
 			}, [
 				m('form', {
 					onsubmit: submitSearch

--- a/src/js/Editors/Tiles.js
+++ b/src/js/Editors/Tiles.js
@@ -2,6 +2,8 @@ import m from 'mithril'
 
 import Tile from '../Components/Tile'
 
+const OMDB_API_KEY = import.meta.env.VITE_OMDB_API_KEY
+
 const NoteTile = {
 	view: ({ attrs }) => m(Tile, {
 		href: '/new/note',
@@ -86,15 +88,40 @@ const BookTile = {
 	})
 }
 
-export {
-	NoteTile,
-	ArticleTile,
-	ReplyTile,
-	BookmarkTile,
-	LikeTile,
-	ImageTile,
-	RSVPTile,
-	RecipeTile,
-	MovieTile,
-	BookTile
+const PostTypes = {
+	note: NoteTile,
+	image: ImageTile,
+	reply: ReplyTile,
+	bookmark: BookmarkTile,
+	like: LikeTile,
+	article: ArticleTile,
+	rsvp: RSVPTile,
+	watch: OMDB_API_KEY ? MovieTile : null,
+	read: BookTile
 }
+
+const Tiles = (types, defaultTiles) => {
+	if (!defaultTiles || !defaultTiles.length) {
+		defaultTiles = [ 'note', 'image', 'reply', 'bookmark', 'like', 'article', 'rsvp', 'watch', 'read' ]
+	}
+	if (!types || !types.length) {
+		types = defaultTiles.map(t => ({ type: t }))
+	}
+	const tiles = types
+		.filter(pt => PostTypes[pt.type] && defaultTiles.includes(pt.type))
+		.map(pt => m(PostTypes[pt.type], { name: pt.name })) || []
+
+	return {
+		view: () =>
+			tiles && tiles.length ? m('.sp-tiles', tiles) : [
+				m('h3', 'no available tiles'),
+				m('p', [
+					'unsupported post types ',
+					m('a', { href: 'https://github.com/indieweb/micropub-extensions/issues/1', target: '_blank' },
+					m('i.far.fa-circle-question', { title: 'query for supported vocabulary discussion' }))
+				])
+			]
+	}
+}
+
+export default Tiles

--- a/src/js/Editors/Tiles.js
+++ b/src/js/Editors/Tiles.js
@@ -3,18 +3,18 @@ import m from 'mithril'
 import Tile from '../Components/Tile'
 
 const NoteTile = {
-	view: () => m(Tile, {
+	view: ({ attrs }) => m(Tile, {
 		href: '/new/note',
 		icon: '.far.fa-note-sticky',
-		name: 'Note'
+		name: attrs?.name || 'Note'
 	})
 }
 
 const ArticleTile = {
-	view: () => m(Tile, {
+	view: ({ attrs }) => m(Tile, {
 		href: '/new/article',
 		icon: '.fas.fa-newspaper',
-		name: 'Article'
+		name: attrs?.name || 'Article'
 	})
 }
 
@@ -23,7 +23,7 @@ const LikeTile = {
 		m(Tile, {
 			href: `/new/like${attrs.params ? '?' + attrs.params : ''}`,
 			icon: '.fas.fa-heart',
-			name: 'Like'
+			name: attrs?.name || 'Like'
 		})
 }
 
@@ -32,7 +32,7 @@ const ReplyTile = {
 		m(Tile, {
 			href: `/new/reply${attrs.params ? '?' + attrs.params : ''}`,
 			icon: '.fas.fa-reply',
-			name: 'Reply'
+			name: attrs?.name || 'Reply'
 		})
 }
 
@@ -48,7 +48,7 @@ const RSVPTile = {
 	view: ({ attrs }) => m(Tile, {
 		href: `/new/rsvp${attrs.params ? '?' + attrs.params : ''}`,
 		icon: '.far.fa-calendar-check',
-		name: 'RSVP'
+		name: attrs?.name || 'RSVP'
 	})
 }
 
@@ -57,32 +57,32 @@ const BookmarkTile = {
 		m(Tile, {
 			href: `/new/bookmark${attrs.params ? '?' + attrs.params : ''}`,
 			icon: '.far.fa-bookmark',
-			name: 'Bookmark'
+			name: attrs?.name || 'Bookmark'
 		})
 }
 
 const RecipeTile = {
-	view: () => m(Tile, {
+	view: ({ attrs }) => m(Tile, {
 		href: '/new/recipe',
 		icon: '.fas.fa-utensils',
-		name: 'Recipe',
+		name: attrs?.name || 'Recipe',
 		disabled: true
 	})
 }
 
 const MovieTile = {
-	view: () => m(Tile, {
+	view: ({ attrs }) => m(Tile, {
 		href: '/new/movie',
 		icon: '.fas.fa-film',
-		name: 'Movie'
+		name: attrs?.name || 'Movie'
 	})
 }
 
 const BookTile = {
-	view: () => m(Tile, {
+	view: ({ attrs }) => m(Tile, {
 		href: '/new/book',
 		icon: '.fas.fa-book',
-		name: 'Book'
+		name: attrs?.name || 'Book'
 	})
 }
 

--- a/src/js/Editors/index.js
+++ b/src/js/Editors/index.js
@@ -66,6 +66,7 @@ const EditorTypes = {
 
 const Editor = ({ attrs }) => {
 	const parameterList = new URLSearchParams(window.location.search)
+	const postTypes = Store.getSession('post-types') || []
 	const params = {
 		title: parameterList.get('title'),
 		text: parameterList.get('text'),
@@ -142,11 +143,13 @@ const Editor = ({ attrs }) => {
 		}
 	}
 
+	const postType = postTypes.find(item => item.type == attrs.title.toLowerCase())
+
 	return {
 		view: () =>
 			m(Box, {
 				icon: attrs.icon, //'.far.fa-note-sticky',
-				title: attrs.title //'Note'
+				title: postType?.name || attrs.title //'Note'
 			}, m('form', {
 				onsubmit: post
 			}, [

--- a/src/js/Pages/HomePage.js
+++ b/src/js/Pages/HomePage.js
@@ -21,9 +21,17 @@ const HomePage = () => {
 	const me = Store.getMe()
 	const postTypes = Store.getSession('post-types') || []
 
-	const getPostTypeName = (type) => {
-		const postType = postTypes.find(item => item.type === type)
-		return postType ? postType.name : false
+	const getPostType = (type) => {
+		return postTypes.find(item => item.type === type)
+	}
+
+	const postTypeTile = (type, tile) => {
+		if (!postTypes) {
+			return m(tile)
+		}
+
+		const postType = getPostType(type)
+		return postType ? m(tile, { name: postType.name }) : null
 	}
 
 	return {
@@ -31,17 +39,17 @@ const HomePage = () => {
 		view: () => [
 			m(Box, [
 				m('.sp-tiles', [
-					m(NoteTile, { name: getPostTypeName('note') }),
+					postTypeTile('note', NoteTile),
 					m(ImageTile),
-					m(ReplyTile, { name: getPostTypeName('note') }),
-					m(BookmarkTile, { name: getPostTypeName('bookmark') }),
-					m(LikeTile, { name: getPostTypeName('like') }),
-					m(ArticleTile, { name: getPostTypeName('article') }),
-					m(RSVPTile, { name: getPostTypeName('rsvp') }),
+					postTypeTile('reply', ReplyTile),
+					postTypeTile('bookmark', BookmarkTile),
+					postTypeTile('like', LikeTile),
+					postTypeTile('article', ArticleTile),
+					postTypeTile('rsvp', RSVPTile),
 					OMDB_API_KEY
-						? m(MovieTile, { name: getPostTypeName('watch') })
+						? postTypeTile('watch', MovieTile)
 						: null,
-					m(BookTile, { name: getPostTypeName('read') })
+					postTypeTile('read', BookTile)
 				])
 			]),
 			m('section', [

--- a/src/js/Pages/HomePage.js
+++ b/src/js/Pages/HomePage.js
@@ -2,56 +2,17 @@ import m from 'mithril'
 
 import { Box } from '../Components/Box'
 import { fetchMicropubConfig } from '../Controllers/Helpers'
-import {
-	NoteTile,
-	ImageTile,
-	ReplyTile,
-	BookmarkTile,
-	LikeTile,
-	ArticleTile,
-	RSVPTile,
-	MovieTile,
-	BookTile
-} from '../Editors/Tiles'
+import Tiles from '../Editors/Tiles'
 import Store from '../Models/Store'
-
-const OMDB_API_KEY = import.meta.env.VITE_OMDB_API_KEY
 
 const HomePage = () => {
 	const me = Store.getMe()
 	const postTypes = Store.getSession('post-types') || []
 
-	const getPostType = (type) => {
-		return postTypes.find(item => item.type === type)
-	}
-
-	const postTypeTile = (type, tile) => {
-		if (!postTypes) {
-			return m(tile)
-		}
-
-		const postType = getPostType(type)
-		return postType ? m(tile, { name: postType.name }) : null
-	}
-
 	return {
 		oninit: () => fetchMicropubConfig(),
 		view: () => [
-			m(Box, [
-				m('.sp-tiles', [
-					postTypeTile('note', NoteTile),
-					m(ImageTile),
-					postTypeTile('reply', ReplyTile),
-					postTypeTile('bookmark', BookmarkTile),
-					postTypeTile('like', LikeTile),
-					postTypeTile('article', ArticleTile),
-					postTypeTile('rsvp', RSVPTile),
-					OMDB_API_KEY
-						? postTypeTile('watch', MovieTile)
-						: null,
-					postTypeTile('read', BookTile)
-				])
-			]),
+			m(Box, m(Tiles(postTypes))),
 			m('section', [
 				m('p', [
 					'Logged in as ',

--- a/src/js/Pages/HomePage.js
+++ b/src/js/Pages/HomePage.js
@@ -7,10 +7,14 @@ import Store from '../Models/Store'
 
 const HomePage = () => {
 	const me = Store.getMe()
-	const postTypes = Store.getSession('post-types') || []
+	let postTypes = []
 
 	return {
-		oninit: () => fetchMicropubConfig(),
+		oninit: async () => {
+			await fetchMicropubConfig()
+			postTypes = Store.getSession('post-types') || []
+			m.redraw()
+		},
 		view: () => [
 			m(Box, m(Tiles(postTypes))),
 			m('section', [

--- a/src/js/Pages/HomePage.js
+++ b/src/js/Pages/HomePage.js
@@ -19,21 +19,29 @@ const OMDB_API_KEY = import.meta.env.VITE_OMDB_API_KEY
 
 const HomePage = () => {
 	const me = Store.getMe()
+	const postTypes = Store.getSession('post-types') || []
+
+	const getPostTypeName = (type) => {
+		const postType = postTypes.find(item => item.type === type)
+		return postType ? postType.name : false
+	}
 
 	return {
 		oninit: () => fetchMicropubConfig(),
 		view: () => [
 			m(Box, [
 				m('.sp-tiles', [
-					m(NoteTile),
+					m(NoteTile, { name: getPostTypeName('note') }),
 					m(ImageTile),
-					m(ReplyTile),
-					m(BookmarkTile),
-					m(LikeTile),
-					m(ArticleTile),
-					m(RSVPTile),
-					OMDB_API_KEY ? m(MovieTile) : null,
-					m(BookTile)
+					m(ReplyTile, { name: getPostTypeName('note') }),
+					m(BookmarkTile, { name: getPostTypeName('bookmark') }),
+					m(LikeTile, { name: getPostTypeName('like') }),
+					m(ArticleTile, { name: getPostTypeName('article') }),
+					m(RSVPTile, { name: getPostTypeName('rsvp') }),
+					OMDB_API_KEY
+						? m(MovieTile, { name: getPostTypeName('watch') })
+						: null,
+					m(BookTile, { name: getPostTypeName('read') })
 				])
 			]),
 			m('section', [

--- a/src/js/Pages/SharePage.js
+++ b/src/js/Pages/SharePage.js
@@ -1,14 +1,10 @@
 import m from 'mithril'
 
 import { Box } from '../Components/Box'
-import {
-	LikeTile,
-	ReplyTile,
-	RSVPTile,
-	BookmarkTile
-} from '../Editors/Tiles'
+import Tiles from '../Editors/Tiles'
 
 const SharePage = () => {
+	const postTypes = Store.getSession('post-types') || []
 	const parameterList = new URLSearchParams(window.location.search)
 	const params = {
 		title: parameterList.get('title'),
@@ -40,12 +36,7 @@ const SharePage = () => {
 					m('b', 'url:'),
 					params.url
 				]),
-				m('.sp-tiles', [
-					m(ReplyTile, { params: parameterList.toString() }),
-					m(BookmarkTile, { params: parameterList.toString() }),
-					m(LikeTile, { params: parameterList.toString() }),
-					m(RSVPTile, { params: parameterList.toString() })
-				])
+				m(Tiles(postTypes, [ 'reply', 'bookmark', 'like', 'rsvp' ]))
 			])
 	}
 }

--- a/src/js/Pages/SharePage.js
+++ b/src/js/Pages/SharePage.js
@@ -2,6 +2,7 @@ import m from 'mithril'
 
 import { Box } from '../Components/Box'
 import Tiles from '../Editors/Tiles'
+import Store from '../Models/Store'
 
 const SharePage = () => {
 	const postTypes = Store.getSession('post-types') || []

--- a/src/scss/_ui.scss
+++ b/src/scss/_ui.scss
@@ -49,7 +49,7 @@
 
 .sp-tiles {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(75px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(75px, 1fr));
 	grid-gap: .75em;
 
 	button {


### PR DESCRIPTION
This PR adds support for [querying for supported vocabularies](https://github.com/indieweb/micropub-extensions/issues/1) and using any preferred names for relevant post types in Sparkles’ interface.

For example, querying my test endpoint, I get the following response (truncated, only relevant objects shown):

```json
"post-types": [
  {
    "type": "like",
    "name": "Favourite"
  },
  {
    "type": "watch",
    "name": "Film"
  },
]
```

This results in the interface adapting such that ‘Favourite’ is shown instead of ‘Like’ and ‘Film’ is shown instead of ‘Movie’:

<img src="https://github.com/benjifs/sparkles/assets/813383/de90c838-0ab5-43f2-a2af-adda190500bd" alt="Home page of Sparkles showing post options with preferred names for 2 post options." width="480">