### PR TITLE
Discover relative endpoint URLs

### DIFF
--- a/src/functions/discover.js
+++ b/src/functions/discover.js
@@ -5,7 +5,7 @@ import { isValidURL, Response, Error } from './lib/utils'
 const requiredRels = ['authorization_endpoint', 'token_endpoint', 'micropub']
 
 const getRelURL = ($, rel) => $ && rel ? $(`[rel='${rel}']`).attr('href') : null
-const absoluteURL = (url, baseURL) => url && !url.match(/^https?:\/\//) ? `${baseURL}${url}` : url
+const absoluteURL = (url, baseURL) => url ? new URL(url, baseURL).href : null
 
 exports.handler = async e => {
 	const urlString = e.queryStringParameters.url


### PR DESCRIPTION
While testing sparkles against a friend's homebrew IndieAuth+Micropub server, the relative authorization_endpoint caused the redirect URL to contain a double slash like `https://domain//authorization`. This PR changes discover.js to resolve relative endpoints with `new URL(url, base).href`. I don't know if this breaks any expected behaviors, though, so merge at your own discretion.