### PR TITLE
Fix: Typo in mithril.js.org URL

### DIFF
--- a/src/js/Pages/AboutPage.js
+++ b/src/js/Pages/AboutPage.js
@@ -23,7 +23,7 @@ const AboutPage = {
 			]),
 			m('p', [
 				'Built with ',
-				m('a', { href: 'https://mithriljs.org', target: '_blank' }, 'MithrilJS'),
+				m('a', { href: 'https://mithril.js.org', target: '_blank' }, 'MithrilJS'),
 				', ',
 				m('a', { href: 'https://sass-lang.com', target: '_blank' }, 'SCSS'),
 				', and ',


### PR DESCRIPTION
The URL for mithril.js should be `mithril.js.org` (see also the kinda cool https://js.org/ project), not `mithriljs.org`.

Absolutely minor thing, but as your project is open source (thanks for that!), I thought I'd take the time and open a PR.